### PR TITLE
Fix `process.cwd()` path issue in Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,17 @@
 const CMZ_NAME = 'cmz'
 
-const root = process.cwd()
+const root = slash(process.cwd())
+
+function slash (input) {
+  const isExtendedLengthPath = /^\\\\\?\\/.test(input)
+  const hasNonAscii = /[^\u0000-\u0080]+/.test(input)
+
+  if (isExtendedLengthPath || hasNonAscii) {
+    return input
+  }
+
+  return input.replace(/\\/g, '/')
+}
 
 function isRule (raw) {
   return raw.indexOf(':') > 0


### PR DESCRIPTION
Node.js's `path` methods return `\\` paths in Windows instead of the usual `/` in Unix based OSs.

Because of that, when running `cmz` in Windows the generated class names would actually contain the entire path of the current file instead of just the relative path of the project as is expected.

This fixes this issue by transforming the returning path from `process.cwd` into a Unix-like form.

```js
const root = process.cwd()
// Unix => foo/bar
// Windows => foo\\bar

slash(root)
// Unix => foo/bar
// Windows => foo/bar
```

Here's an example of the bug in action extracted from the https://github.com/x-team/auto-ui project. In this Windows environment, the repo is located at `D:\repos\auto-ui\`. When computing the class names, the babel plugin fails to strip the current working directory path, and that causes *all* the snapshots to fail.

![image](https://user-images.githubusercontent.com/7514993/47190419-3f040b80-d30f-11e8-9246-84b564e44530.png)


